### PR TITLE
Use assembly reference paths to make collaboration easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A simple Cities: Skylines mod that adds a "Clear Everything" button to the Chirp
 
 1. Clone the source.
 2. Open in Visual Studio (tested on 2013).
-3. Fix the references to `ICities`, `UnityEngine`, `Assembly-CSharp`, and `ColossalManaged`
-  1. These are found in `steamapps\common\Cities_Skylines\Cities_Data\Managed`
+3. Add the game assembly path to the project reference paths.
+  1. The path is `[SteamLibrary]\steamapps\common\Cities_Skylines\Cities_Data\Managed`, where `[SteamLibrary]` is your Steam library folder.
 4. Build.
 
 ## What if I just want the mod to install it?

--- a/src/SkyModChirpyMaid/SkyModChirpyMaid/SkyModChirpyMaid.csproj
+++ b/src/SkyModChirpyMaid/SkyModChirpyMaid/SkyModChirpyMaid.csproj
@@ -30,19 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\SteamGames\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="ColossalManaged">
-      <HintPath>..\..\..\..\..\..\SteamGames\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
-    </Reference>
-    <Reference Include="ICities">
-      <HintPath>..\..\..\..\..\..\SteamGames\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
-    </Reference>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
+    <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL" />
+    <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
     <Reference Include="System" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\SteamGames\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChirpyMaidMod.cs" />


### PR DESCRIPTION
Using direct references to the game assemblies makes collaborating on the project harder than it should be:
- References must be fixed after checking out the source.
- One must be careful not to commit the altered reference paths.

Using [reference paths](https://msdn.microsoft.com/en-us/library/vstudio/6taasyc6%28v=vs.100%29.aspx) solves both problems at once:
- Assembly references don't have to be fixed, because they are relative to the local reference path.
- Reference paths are part of the project's user settings and as such not checked into the repository.

This PR changes the project to use reference paths. It also updates the build instructions accordingly.

Note that to add other game assembly references, you should pick them from the "Assemblies -> Extensions" list in the Reference Manager.
